### PR TITLE
Add workflow to generate release notes on PR merge and document it in README

### DIFF
--- a/.github/workflows/release-notes-on-main-merge.yml
+++ b/.github/workflows/release-notes-on-main-merge.yml
@@ -1,0 +1,17 @@
+name: Release Notes on Main Merge
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  release-notes:
+    if: ${{ github.event.pull_request.merged == true }}
+    uses: medimohammadise/elegant-ci-cd-pipeline/.github/workflows/reusable-release-notes.yml@001-release-notes-workflow
+    with:
+      base_sha: ${{ github.event.pull_request.base.sha }}
+      head_sha: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
+      target_branch: ${{ github.event.pull_request.base.ref }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This repository contains the infrastructure configuration for provisioning a Docker registry, Postgres, a UI, and a 5-node remote Kubernetes (`kind`) cluster over SSH, along with a required namespace using Terraform.
 
+
+## GitHub Release Notes Automation
+
+This repository includes a caller workflow at `.github/workflows/release-notes-on-main-merge.yml` that invokes the reusable Release Notes workflow from `medimohammadise/elegant-ci-cd-pipeline` on branch `001-release-notes-workflow`.
+
+When a pull request is merged into `main`, this workflow forwards the merge commit range (`base_sha` and `head_sha`) to that reusable workflow.
+
 ## Prerequisites
 
 - SSH access to the remote host (e.g. `myserver`) where Docker is running.


### PR DESCRIPTION
### Motivation
- Automatically generate release notes when a pull request is merged into `main` by invoking a reusable release-notes workflow. 

### Description
- Add a caller workflow at `.github/workflows/release-notes-on-main-merge.yml` that triggers on closed PRs merged into `main` and forwards `base_sha` and `head_sha` to the reusable workflow `medimohammadise/elegant-ci-cd-pipeline/.github/workflows/reusable-release-notes.yml@001-release-notes-workflow`.
- Update `README.md` to document the new GitHub Release Notes automation and the location of the caller workflow.

### Testing
- No automated tests were run as part of this change and no existing test behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc420dbee8832586795cd4c26f488f)