### PR TITLE
Add Keycloak component and module (K8s deployment + kind port mapping)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # elegant-infra-engine
 
-This repository provisions a remote Docker registry, PostgreSQL, a `kind` Kubernetes cluster, Backstage, and Kubernetes Dashboard with Terraform. The layout is now split into reusable modules and deployable component roots so you can apply the full platform or only the parts you need.
+This repository provisions a remote Docker registry, PostgreSQL, a `kind` Kubernetes cluster, Backstage, Keycloak, and Kubernetes Dashboard with Terraform. The layout is now split into reusable modules and deployable component roots so you can apply the full platform or only the parts you need.
 
 ## Layout
 
@@ -12,6 +12,7 @@ components/
   kind-cluster/         Deploy the remote kind cluster
   backstage/            Deploy Backstage into an existing cluster
   kubernetes-dashboard/ Deploy Kubernetes Dashboard into an existing cluster
+  keycloak/             Deploy Keycloak into an existing cluster
 modules/
   Reusable Terraform modules shared by the component roots
 scripts/
@@ -32,6 +33,7 @@ flowchart TD
   Components --> KindComponent["kind-cluster/"]
   Components --> BackstageComponent["backstage/"]
   Components --> DashboardComponent["kubernetes-dashboard/"]
+  Components --> KeycloakComponent["keycloak/"]
 
   Modules --> DockerNetwork["docker-network/"]
   Modules --> RegistryModule["docker-registry/"]
@@ -41,6 +43,7 @@ flowchart TD
   Modules --> NamespaceModule["k8s-namespace/"]
   Modules --> BackstageModule["backstage/"]
   Modules --> DashboardModule["kubernetes-dashboard/"]
+  Modules --> KeycloakModule["keycloak/"]
 
   Scripts --> BackstageScript["backstage-postrender.sh"]
 ```
@@ -57,6 +60,7 @@ flowchart TD
   All --> Namespace["modules/k8s-namespace"]
   All --> Backstage["modules/backstage"]
   All --> Dashboard["modules/kubernetes-dashboard"]
+  All --> Keycloak["modules/keycloak"]
 
   RegistryComponent["components/docker-registry"] --> DockerNetwork
   RegistryComponent --> Registry
@@ -70,6 +74,8 @@ flowchart TD
   BackstageComponent --> Backstage
   DashboardComponent["components/kubernetes-dashboard"] --> Namespace
   DashboardComponent --> Dashboard
+  KeycloakComponent["components/keycloak"] --> Namespace
+  KeycloakComponent --> Keycloak
 ```
 
 ```mermaid
@@ -78,6 +84,7 @@ flowchart LR
   PostgresDb["PostgreSQL"] --> BackstageApp
   KindCluster["kind Cluster"] --> BackstageApp
   KindCluster --> DashboardUi["Kubernetes Dashboard"]
+  KindCluster --> KeycloakUi["Keycloak"]
 ```
 
 ## Prerequisites
@@ -140,6 +147,7 @@ Use the component roots when you want independent deployment lifecycles:
 - `components/kind-cluster` for the remote `kind` cluster and kubeconfig
 - `components/backstage` for Backstage on an existing cluster
 - `components/kubernetes-dashboard` for Dashboard on an existing cluster
+- `components/keycloak` for Keycloak on an existing cluster
 
 Each component root has its own `terraform.tfvars.example`.
 
@@ -181,6 +189,18 @@ backstage = {
   expose_public = true
   node_port     = 32007
   host_port     = 7007
+}
+
+keycloak = {
+  enabled        = false
+  namespace      = "keycloak"
+  image_tag      = "26.5.5"
+  replicas       = 1
+  expose_public  = false
+  node_port      = 32080
+  host_port      = 8080
+  admin_username = "admin"
+  admin_password = "change-me"
 }
 ```
 
@@ -224,7 +244,7 @@ terraform plan
 terraform apply
 ```
 
-This root creates the remote `kind` cluster and writes a kubeconfig file locally. If you want public Backstage or Dashboard access later, reserve the needed host-port mappings here with `backstage_port_mapping` and `dashboard_port_mapping`.
+This root creates the remote `kind` cluster and writes a kubeconfig file locally. If you want public Backstage, Dashboard, or Keycloak access later, reserve the needed host-port mappings here with `backstage_port_mapping`, `dashboard_port_mapping`, and `keycloak_port_mapping`.
 
 ### Backstage
 
@@ -257,6 +277,18 @@ Generate a dashboard login token with:
 ```bash
 kubectl --kubeconfig <path-to-kubeconfig> -n kubernetes-dashboard create token admin-user
 ```
+
+### Keycloak
+
+```bash
+cd components/keycloak
+cp terraform.tfvars.example terraform.tfvars
+terraform init
+terraform plan
+terraform apply
+```
+
+If `keycloak.expose_public = true`, the cluster must already have the matching host-port mapping reserved by `components/kind-cluster` or `components/all`.
 
 ## Force Recreate
 

--- a/components/all/main.tf
+++ b/components/all/main.tf
@@ -69,6 +69,10 @@ module "kind_cluster" {
     node_port = var.dashboard.node_port
     host_port = var.dashboard.host_port
   } : null
+  keycloak_port_mapping = var.keycloak.enabled && var.keycloak.expose_public ? {
+    node_port = var.keycloak.node_port
+    host_port = var.keycloak.host_port
+  } : null
   recreate_revision = trimspace(try(var.kubernetes.recreate_revision, "")) != "" ? var.kubernetes.recreate_revision : var.recreate_revision
 
   depends_on = [module.postgres]
@@ -140,4 +144,30 @@ module "kubernetes_dashboard" {
   recreate_revision = trimspace(try(var.dashboard.recreate_revision, "")) != "" ? var.dashboard.recreate_revision : var.recreate_revision
 
   depends_on = [module.dashboard_namespace]
+}
+
+module "keycloak_namespace" {
+  count  = var.keycloak.enabled ? 1 : 0
+  source = "../../modules/k8s-namespace"
+
+  name = var.keycloak.namespace
+
+  depends_on = [terraform_data.kind_cluster_ready]
+}
+
+module "keycloak" {
+  count  = var.keycloak.enabled ? 1 : 0
+  source = "../../modules/keycloak"
+
+  namespace         = module.keycloak_namespace[0].name
+  image_repository  = var.keycloak.image_repository
+  image_tag         = var.keycloak.image_tag
+  replicas          = var.keycloak.replicas
+  service_type      = var.keycloak.expose_public ? "NodePort" : "ClusterIP"
+  node_port         = var.keycloak.expose_public ? var.keycloak.node_port : null
+  admin_username    = var.keycloak.admin_username
+  admin_password    = var.keycloak.admin_password
+  recreate_revision = trimspace(try(var.keycloak.recreate_revision, "")) != "" ? var.keycloak.recreate_revision : var.recreate_revision
+
+  depends_on = [module.keycloak_namespace]
 }

--- a/components/all/outputs.tf
+++ b/components/all/outputs.tf
@@ -41,3 +41,8 @@ output "dashboard_url" {
   description = "Configured Kubernetes Dashboard URL when publicly exposed."
   value       = var.dashboard.enabled && var.dashboard.expose_public ? "https://${var.api_server_host}:${var.dashboard.host_port}" : null
 }
+
+output "keycloak_url" {
+  description = "Configured Keycloak URL when publicly exposed."
+  value       = var.keycloak.enabled && var.keycloak.expose_public ? "http://${var.api_server_host}:${var.keycloak.host_port}" : null
+}

--- a/components/all/terraform.tfvars.example
+++ b/components/all/terraform.tfvars.example
@@ -51,4 +51,17 @@ dashboard = {
   admin_user_name   = "admin-user"
 }
 
+
+keycloak = {
+  enabled        = false
+  namespace      = "keycloak"
+  image_tag      = "26.5.5"
+  replicas       = 1
+  expose_public  = false
+  node_port      = 32080
+  host_port      = 8080
+  admin_username = "admin"
+  admin_password = "change-me"
+}
+
 recreate_revision = ""

--- a/components/all/variables.tf
+++ b/components/all/variables.tf
@@ -93,6 +93,26 @@ variable "dashboard" {
   default     = {}
 }
 
+
+variable "keycloak" {
+  type = object({
+    enabled           = optional(bool, false)
+    namespace         = optional(string, "keycloak")
+    image_repository  = optional(string, "quay.io/keycloak/keycloak")
+    image_tag         = optional(string, "26.5.5")
+    replicas          = optional(number, 1)
+    expose_public     = optional(bool, false)
+    node_port         = optional(number, 32080)
+    host_port         = optional(number, 8080)
+    admin_username    = optional(string, "admin")
+    admin_password    = optional(string, "change-me")
+    recreate_revision = optional(string, "")
+  })
+  description = "Keycloak deployment settings."
+  sensitive   = true
+  default     = {}
+}
+
 variable "recreate_revision" {
   type        = string
   description = "Global replacement token passed to modules that support one-shot recreation."

--- a/components/keycloak/main.tf
+++ b/components/keycloak/main.tf
@@ -1,0 +1,21 @@
+module "keycloak_namespace" {
+  source = "../../modules/k8s-namespace"
+
+  name = var.keycloak.namespace
+}
+
+module "keycloak" {
+  source = "../../modules/keycloak"
+
+  namespace         = module.keycloak_namespace.name
+  image_repository  = var.keycloak.image_repository
+  image_tag         = var.keycloak.image_tag
+  replicas          = var.keycloak.replicas
+  service_type      = var.keycloak.expose_public ? "NodePort" : "ClusterIP"
+  node_port         = var.keycloak.expose_public ? var.keycloak.node_port : null
+  admin_username    = var.keycloak.admin_username
+  admin_password    = var.keycloak.admin_password
+  recreate_revision = trimspace(try(var.keycloak.recreate_revision, "")) != "" ? var.keycloak.recreate_revision : var.recreate_revision
+
+  depends_on = [module.keycloak_namespace]
+}

--- a/components/keycloak/outputs.tf
+++ b/components/keycloak/outputs.tf
@@ -1,0 +1,14 @@
+output "namespace" {
+  description = "Keycloak namespace."
+  value       = module.keycloak.namespace
+}
+
+output "name" {
+  description = "Keycloak workload name."
+  value       = module.keycloak.name
+}
+
+output "service_name" {
+  description = "Keycloak Service name."
+  value       = module.keycloak.service_name
+}

--- a/components/keycloak/providers.tf
+++ b/components/keycloak/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path = var.kubeconfig_path
+  insecure    = true
+}

--- a/components/keycloak/terraform.tfvars.example
+++ b/components/keycloak/terraform.tfvars.example
@@ -1,0 +1,14 @@
+kubeconfig_path = "./blitzinfra-kubeconfig"
+cluster_name    = "blitzinfra"
+
+keycloak = {
+  namespace      = "keycloak"
+  image_tag      = "26.5.5"
+  replicas       = 1
+  expose_public  = false
+  node_port      = 32080
+  admin_username = "admin"
+  admin_password = "change-me"
+}
+
+recreate_revision = ""

--- a/components/keycloak/variables.tf
+++ b/components/keycloak/variables.tf
@@ -1,0 +1,33 @@
+variable "kubeconfig_path" {
+  type        = string
+  description = "Path to the kubeconfig file of the target cluster."
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "kind cluster name used by the kubeconfig context."
+  default     = "blitzinfra"
+}
+
+variable "keycloak" {
+  type = object({
+    namespace         = optional(string, "keycloak")
+    image_repository  = optional(string, "quay.io/keycloak/keycloak")
+    image_tag         = optional(string, "26.5.5")
+    replicas          = optional(number, 1)
+    expose_public     = optional(bool, false)
+    node_port         = optional(number, 32080)
+    admin_username    = optional(string, "admin")
+    admin_password    = optional(string, "change-me")
+    recreate_revision = optional(string, "")
+  })
+  description = "Keycloak settings."
+  sensitive   = true
+  default     = {}
+}
+
+variable "recreate_revision" {
+  type        = string
+  description = "Change this token to force replacement of the Keycloak resources."
+  default     = ""
+}

--- a/components/kind-cluster/main.tf
+++ b/components/kind-cluster/main.tf
@@ -10,5 +10,6 @@ module "kind_cluster" {
   kubeconfig_path        = try(var.kubernetes.kubeconfig_path, null)
   backstage_port_mapping = var.backstage_port_mapping
   dashboard_port_mapping = var.dashboard_port_mapping
+  keycloak_port_mapping = var.keycloak_port_mapping
   recreate_revision      = var.recreate_revision
 }

--- a/components/kind-cluster/terraform.tfvars.example
+++ b/components/kind-cluster/terraform.tfvars.example
@@ -18,4 +18,10 @@ dashboard_port_mapping = {
   host_port = 8443
 }
 
+
+keycloak_port_mapping = {
+  node_port = 32080
+  host_port = 8080
+}
+
 recreate_revision = ""

--- a/components/kind-cluster/variables.tf
+++ b/components/kind-cluster/variables.tf
@@ -38,6 +38,16 @@ variable "dashboard_port_mapping" {
   default     = null
 }
 
+
+variable "keycloak_port_mapping" {
+  type = object({
+    node_port = number
+    host_port = number
+  })
+  description = "Optional NodePort to host-port mapping reserved for Keycloak."
+  default     = null
+}
+
 variable "recreate_revision" {
   type        = string
   description = "Change this token to force replacement of the kind cluster."

--- a/modules/keycloak/main.tf
+++ b/modules/keycloak/main.tf
@@ -1,0 +1,147 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}
+
+resource "terraform_data" "recreate" {
+  input = var.recreate_revision
+}
+
+resource "kubernetes_secret" "admin_credentials" {
+  metadata {
+    name      = "${var.name}-admin"
+    namespace = var.namespace
+  }
+
+  data = {
+    KEYCLOAK_ADMIN          = var.admin_username
+    KEYCLOAK_ADMIN_PASSWORD = var.admin_password
+  }
+
+  type = "Opaque"
+
+  lifecycle {
+    replace_triggered_by = [terraform_data.recreate]
+  }
+}
+
+resource "kubernetes_deployment" "this" {
+  metadata {
+    name      = var.name
+    namespace = var.namespace
+    labels = {
+      app = var.name
+    }
+  }
+
+  spec {
+    replicas = var.replicas
+
+    selector {
+      match_labels = {
+        app = var.name
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = var.name
+        }
+      }
+
+      spec {
+        container {
+          name              = var.name
+          image             = "${var.image_repository}:${var.image_tag}"
+          image_pull_policy = "IfNotPresent"
+          args              = ["start-dev", "--http-enabled=true", "--hostname-strict=false"]
+
+          env {
+            name = "KEYCLOAK_ADMIN"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.admin_credentials.metadata[0].name
+                key  = "KEYCLOAK_ADMIN"
+              }
+            }
+          }
+
+          env {
+            name = "KEYCLOAK_ADMIN_PASSWORD"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.admin_credentials.metadata[0].name
+                key  = "KEYCLOAK_ADMIN_PASSWORD"
+              }
+            }
+          }
+
+          port {
+            container_port = 8080
+            name           = "http"
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/realms/master"
+              port = 8080
+            }
+
+            initial_delay_seconds = 30
+            period_seconds        = 10
+            timeout_seconds       = 5
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/realms/master"
+              port = 8080
+            }
+
+            initial_delay_seconds = 60
+            period_seconds        = 15
+            timeout_seconds       = 5
+          }
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    replace_triggered_by = [terraform_data.recreate]
+  }
+}
+
+resource "kubernetes_service" "this" {
+  metadata {
+    name      = var.name
+    namespace = var.namespace
+    labels = {
+      app = var.name
+    }
+  }
+
+  spec {
+    selector = {
+      app = var.name
+    }
+
+    type = var.service_type
+
+    port {
+      name        = "http"
+      port        = 80
+      target_port = 8080
+      node_port   = var.service_type == "NodePort" ? var.node_port : null
+    }
+  }
+
+  lifecycle {
+    replace_triggered_by = [terraform_data.recreate]
+  }
+}

--- a/modules/keycloak/outputs.tf
+++ b/modules/keycloak/outputs.tf
@@ -1,0 +1,14 @@
+output "name" {
+  description = "Keycloak workload name."
+  value       = kubernetes_deployment.this.metadata[0].name
+}
+
+output "namespace" {
+  description = "Namespace where Keycloak is installed."
+  value       = kubernetes_deployment.this.metadata[0].namespace
+}
+
+output "service_name" {
+  description = "Kubernetes Service name exposing Keycloak."
+  value       = kubernetes_service.this.metadata[0].name
+}

--- a/modules/keycloak/variables.tf
+++ b/modules/keycloak/variables.tf
@@ -1,0 +1,63 @@
+variable "name" {
+  type        = string
+  description = "Base name used for Keycloak Kubernetes resources."
+  default     = "keycloak"
+}
+
+variable "namespace" {
+  type        = string
+  description = "Namespace where Keycloak is installed."
+}
+
+variable "image_repository" {
+  type        = string
+  description = "Container image repository used for Keycloak."
+  default     = "quay.io/keycloak/keycloak"
+}
+
+variable "image_tag" {
+  type        = string
+  description = "Pinned Keycloak image tag."
+  default     = "26.5.5"
+}
+
+variable "replicas" {
+  type        = number
+  description = "Number of Keycloak pods."
+  default     = 1
+}
+
+variable "service_type" {
+  type        = string
+  description = "Kubernetes Service type used by Keycloak."
+  default     = "ClusterIP"
+
+  validation {
+    condition     = contains(["ClusterIP", "NodePort"], var.service_type)
+    error_message = "service_type must be ClusterIP or NodePort."
+  }
+}
+
+variable "node_port" {
+  type        = number
+  description = "Optional NodePort used when service_type is NodePort."
+  default     = null
+}
+
+variable "admin_username" {
+  type        = string
+  description = "Admin username used to bootstrap Keycloak."
+  default     = "admin"
+}
+
+variable "admin_password" {
+  type        = string
+  description = "Admin password used to bootstrap Keycloak."
+  sensitive   = true
+}
+
+variable "recreate_revision" {
+  type        = string
+  description = "Change this token to force replacement of the Keycloak resources."
+  default     = ""
+}

--- a/modules/kind-cluster/main.tf
+++ b/modules/kind-cluster/main.tf
@@ -65,6 +65,16 @@ resource "kind_cluster" "this" {
           protocol       = "TCP"
         }
       }
+
+      dynamic "extra_port_mappings" {
+        for_each = var.keycloak_port_mapping != null ? [var.keycloak_port_mapping] : []
+        content {
+          container_port = extra_port_mappings.value.node_port
+          host_port      = extra_port_mappings.value.host_port
+          listen_address = "0.0.0.0"
+          protocol       = "TCP"
+        }
+      }
     }
 
     dynamic "node" {

--- a/modules/kind-cluster/variables.tf
+++ b/modules/kind-cluster/variables.tf
@@ -49,6 +49,16 @@ variable "dashboard_port_mapping" {
   default     = null
 }
 
+
+variable "keycloak_port_mapping" {
+  type = object({
+    node_port = number
+    host_port = number
+  })
+  description = "Optional NodePort to host-port mapping for Keycloak."
+  default     = null
+}
+
 variable "kubeconfig_path" {
   type        = string
   description = "Absolute or relative path for the generated kubeconfig file."


### PR DESCRIPTION
### Motivation

- Introduce an optional Keycloak deployment so the platform can provision an identity provider into the Kubernetes cluster alongside Backstage and Dashboard.
- Provide a reusable `modules/keycloak` module and a deployable root `components/keycloak` so Keycloak can be applied independently or as part of the full-stack root.
- Allow public exposure via NodePort with host-port reservation in the `kind` cluster module, and keep a pinned default image/tag while allowing operators to override it.

### Description

- Added a reusable module `modules/keycloak` that creates an admin secret, `Deployment`, `Service`, readiness/liveness probes, and supports `ClusterIP` or `NodePort` exposure with a `recreate_revision` trigger.
- Added a component root `components/keycloak` with provider config, variables, example `terraform.tfvars.example`, and outputs so Keycloak can be deployed against an existing cluster.
- Wired Keycloak into `components/all` as an optional component (new `keycloak` object variable, `module "keycloak"` and namespace module), and exposed `keycloak_url` in `components/all/outputs.tf` when `expose_public` is enabled.
- Extended kind cluster inputs and implementation to support `keycloak_port_mapping` (both in `modules/kind-cluster` and `components/kind-cluster`) and added the extra port-mapping dynamic block so NodePort for Keycloak can be reserved on the host.
- Updated `README.md` to document layout, example tfvars, architecture, and workflow steps for the new Keycloak component.
- Default/pinned Keycloak image tag is `26.5.5` (configurable via `keycloak.image_tag` / `image_tag` variable or `keycloak.image_repository`).

### Testing

- Ran `git diff --check` to validate no whitespace/patch issues and fixed a trailing-blank-line problem; this check passed.
- Attempted `terraform fmt -recursive` as a validation step but it could not be executed in this environment because the `terraform` CLI is not installed (format check not run).
- Committed the changes and created a local commit including the new module and component files (commit completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be024dbd548325a3fdd08049c14bbd)