### PR TITLE
Add observability component (Grafana, Loki, Tempo, Prometheus) for kind clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # elegant-infra-engine
 
-This repository provisions a remote Docker registry, PostgreSQL, a `kind` Kubernetes cluster, Backstage, Headlamp, and Keycloak with Terraform. The layout is now split into reusable modules and deployable component roots so you can apply the full platform or only the parts you need.
+This repository provisions a remote Docker registry, PostgreSQL, a `kind` Kubernetes cluster, Backstage, Headlamp, Keycloak, and an observability stack (Grafana, Loki, Tempo, and Prometheus) with Terraform. The layout is now split into reusable modules and deployable component roots so you can apply the full platform or only the parts you need.
 
 For a consolidated list of exposed endpoints, see [docs/exposed-urls.md](/Users/mehdi/MyProject/elegant-infra-engine/docs/exposed-urls.md).
 
@@ -15,6 +15,7 @@ components/
   backstage/            Deploy Backstage into an existing cluster
   headlamp/             Deploy Headlamp into an existing cluster
   keycloak/             Deploy Keycloak into an existing cluster
+  observability/        Deploy Grafana, Loki, Tempo, and Prometheus into an existing cluster
 modules/
   Reusable Terraform modules shared by the component roots
 scripts/
@@ -36,6 +37,7 @@ flowchart TD
   Components --> BackstageComponent["backstage/"]
   Components --> HeadlampComponent["headlamp/"]
   Components --> KeycloakComponent["keycloak/"]
+  Components --> ObservabilityComponent["observability/"]
 
   Modules --> DockerNetwork["docker-network/"]
   Modules --> RegistryModule["docker-registry/"]
@@ -46,6 +48,7 @@ flowchart TD
   Modules --> BackstageModule["backstage/"]
   Modules --> HeadlampModule["headlamp/"]
   Modules --> KeycloakModule["keycloak/"]
+  Modules --> ObservabilityModule["observability/"]
 
   Scripts --> BackstageScript["backstage-postrender.sh"]
 ```
@@ -77,6 +80,8 @@ flowchart TD
   HeadlampComponent --> Headlamp
   KeycloakComponent["components/keycloak"] --> Namespace
   KeycloakComponent --> KeycloakModule["modules/keycloak"]
+  ObservabilityComponent["components/observability"] --> Namespace
+  ObservabilityComponent --> ObservabilityModule["modules/observability"]
 ```
 
 ```mermaid
@@ -87,6 +92,10 @@ flowchart LR
   KindCluster["kind Cluster"] --> BackstageApp
   KindCluster --> HeadlampUi["Headlamp"]
   KindCluster --> KeycloakApp
+  KindCluster --> GrafanaApp["Grafana"]
+  KindCluster --> LokiApp["Loki"]
+  KindCluster --> TempoApp["Tempo"]
+  KindCluster --> PrometheusApp["Prometheus"]
 ```
 
 ## Prerequisites
@@ -150,6 +159,7 @@ Use the component roots when you want independent deployment lifecycles:
 - `components/backstage` for Backstage on an existing cluster
 - `components/headlamp` for Headlamp on an existing cluster
 - `components/keycloak` for Keycloak on an existing cluster
+- `components/observability` for Grafana, Loki, Tempo, and Prometheus on an existing cluster
 
 Each component root has its own `terraform.tfvars.example`.
 
@@ -300,6 +310,32 @@ When `keycloak.expose_public = true`, access Keycloak at:
 
 ```text
 http://<api_server_host>:8080/
+```
+
+### Observability
+
+```bash
+cd components/observability
+cp terraform.tfvars.example terraform.tfvars
+terraform init
+terraform plan
+terraform apply
+```
+
+This root expects an existing cluster and installs Grafana, Loki, Tempo, and Prometheus in one namespace.
+
+If `observability.expose_public = true`, the cluster must already have a matching host-port mapping reserved by your kind cluster configuration. Otherwise use `kubectl port-forward`.
+
+When `observability.expose_public = true`, access Grafana at:
+
+```text
+http://<api_server_host>:3000
+```
+
+When `observability.expose_public = true` and Prometheus is enabled, access Prometheus at:
+
+```text
+http://<api_server_host>:9090
 ```
 
 ## Force Recreate

--- a/components/all/main.tf
+++ b/components/all/main.tf
@@ -13,6 +13,12 @@ locals {
   )
 
   keycloak_public_url = var.keycloak.enabled && var.keycloak.expose_public ? "http://${var.api_server_host}:${var.keycloak.host_port}/" : null
+  grafana_public_url  = var.observability.enabled && var.observability.expose_public ? "http://${var.api_server_host}:${var.observability.grafana_host_port}" : null
+  prometheus_public_url = (
+    var.observability.enabled && var.observability.expose_public && try(var.observability.prometheus.enabled, true)
+    ? "http://${var.api_server_host}:${var.observability.prometheus_host_port}"
+    : null
+  )
 }
 
 module "docker_network" {
@@ -80,7 +86,19 @@ module "kind_cluster" {
     host_port = var.headlamp.host_port
   } : null
   keycloak_port_mapping = local.keycloak_kind_port_mapping
-  recreate_revision     = trimspace(try(var.kubernetes.recreate_revision, "")) != "" ? var.kubernetes.recreate_revision : var.recreate_revision
+  grafana_port_mapping = var.observability.enabled && var.observability.expose_public ? {
+    node_port = var.observability.grafana_node_port
+    host_port = var.observability.grafana_host_port
+  } : null
+  prometheus_port_mapping = (
+    var.observability.enabled && var.observability.expose_public && try(var.observability.prometheus.enabled, true)
+    ? {
+      node_port = var.observability.prometheus_node_port
+      host_port = var.observability.prometheus_host_port
+    }
+    : null
+  )
+  recreate_revision = trimspace(try(var.kubernetes.recreate_revision, "")) != "" ? var.kubernetes.recreate_revision : var.recreate_revision
 
   depends_on = [module.postgres]
 }
@@ -186,4 +204,33 @@ module "keycloak" {
   recreate_revision = trimspace(try(var.keycloak.recreate_revision, "")) != "" ? var.keycloak.recreate_revision : var.recreate_revision
 
   depends_on = [module.keycloak_namespace]
+}
+
+module "observability_namespace" {
+  count  = var.observability.enabled ? 1 : 0
+  source = "../../modules/k8s-namespace"
+
+  name = var.observability.namespace
+
+  depends_on = [terraform_data.kind_cluster_ready]
+}
+
+module "observability" {
+  count  = var.observability.enabled ? 1 : 0
+  source = "../../modules/observability"
+
+  namespace = module.observability_namespace[0].name
+  grafana = merge(var.observability.grafana, {
+    service_type = var.observability.expose_public ? "NodePort" : "ClusterIP"
+    node_port    = var.observability.expose_public ? var.observability.grafana_node_port : null
+  })
+  loki  = var.observability.loki
+  tempo = var.observability.tempo
+  prometheus = merge(var.observability.prometheus, {
+    service_type = var.observability.expose_public ? "NodePort" : "ClusterIP"
+    node_port    = var.observability.expose_public ? var.observability.prometheus_node_port : null
+  })
+  recreate_revision = var.recreate_revision
+
+  depends_on = [module.observability_namespace]
 }

--- a/components/all/outputs.tf
+++ b/components/all/outputs.tf
@@ -47,6 +47,16 @@ output "keycloak_url" {
   value       = var.keycloak.enabled && var.keycloak.expose_public ? local.keycloak_public_url : var.keycloak_url
 }
 
+output "grafana_url" {
+  description = "Configured Grafana URL when publicly exposed."
+  value       = local.grafana_public_url
+}
+
+output "prometheus_url" {
+  description = "Configured Prometheus URL when publicly exposed."
+  value       = local.prometheus_public_url
+}
+
 output "exposed_urls" {
   description = "Consolidated platform endpoints, including optional external dependencies."
   value = {
@@ -57,8 +67,10 @@ output "exposed_urls" {
       ? "http://${var.registry.ui_bind}:${var.registry.ui_port}"
       : "http://${var.api_server_host}:${var.registry.ui_port}"
     )
-    backstage = var.backstage.enabled ? local.backstage_base_url : null
-    headlamp  = var.headlamp.enabled && var.headlamp.expose_public ? "http://${var.api_server_host}:${var.headlamp.host_port}" : null
-    keycloak  = var.keycloak.enabled && var.keycloak.expose_public ? local.keycloak_public_url : var.keycloak_url
+    backstage  = var.backstage.enabled ? local.backstage_base_url : null
+    headlamp   = var.headlamp.enabled && var.headlamp.expose_public ? "http://${var.api_server_host}:${var.headlamp.host_port}" : null
+    keycloak   = var.keycloak.enabled && var.keycloak.expose_public ? local.keycloak_public_url : var.keycloak_url
+    grafana    = local.grafana_public_url
+    prometheus = local.prometheus_public_url
   }
 }

--- a/components/all/terraform.tfvars.example
+++ b/components/all/terraform.tfvars.example
@@ -61,4 +61,20 @@ headlamp = {
   cluster_role_name           = "cluster-admin"
 }
 
+observability = {
+  enabled              = true
+  namespace            = "observability"
+  expose_public        = true
+  grafana_node_port    = 32300
+  grafana_host_port    = 3000
+  prometheus_node_port = 32090
+  prometheus_host_port = 9090
+  loki = {
+    enabled = false
+  }
+  tempo = {
+    enabled = false
+  }
+}
+
 recreate_revision = ""

--- a/components/all/variables.tf
+++ b/components/all/variables.tf
@@ -143,10 +143,53 @@ variable "ingress_nginx" {
 
 variable "observability" {
   type = object({
-    enabled   = optional(bool, false)
-    namespace = optional(string, "observability")
+    enabled              = optional(bool, false)
+    namespace            = optional(string, "observability")
+    expose_public        = optional(bool, false)
+    grafana_node_port    = optional(number, 32300)
+    grafana_host_port    = optional(number, 3000)
+    prometheus_node_port = optional(number, 32090)
+    prometheus_host_port = optional(number, 9090)
+    grafana = optional(object({
+      release_name     = optional(string, "grafana")
+      chart_repository = optional(string, "https://grafana.github.io/helm-charts")
+      chart_name       = optional(string, "grafana")
+      chart_version    = optional(string, "10.5.15")
+      admin_user       = optional(string, "admin")
+      admin_password   = optional(string, "admin")
+      persistence      = optional(bool, false)
+      persistence_size = optional(string, "5Gi")
+    }), {})
+    loki = optional(object({
+      enabled          = optional(bool, false)
+      release_name     = optional(string, "loki")
+      chart_repository = optional(string, "https://grafana.github.io/helm-charts")
+      chart_name       = optional(string, "loki")
+      chart_version    = optional(string, "6.30.1")
+      persistence      = optional(bool, false)
+      persistence_size = optional(string, "10Gi")
+    }), {})
+    tempo = optional(object({
+      enabled                   = optional(bool, false)
+      release_name              = optional(string, "tempo")
+      chart_repository          = optional(string, "https://grafana.github.io/helm-charts")
+      chart_name                = optional(string, "tempo")
+      chart_version             = optional(string, "1.23.3")
+      persistence               = optional(bool, false)
+      persistence_size          = optional(string, "10Gi")
+      metrics_generator_enabled = optional(bool, true)
+    }), {})
+    prometheus = optional(object({
+      enabled          = optional(bool, true)
+      release_name     = optional(string, "prometheus")
+      chart_repository = optional(string, "https://prometheus-community.github.io/helm-charts")
+      chart_name       = optional(string, "prometheus")
+      chart_version    = optional(string, "27.20.0")
+      persistence      = optional(bool, false)
+      persistence_size = optional(string, "10Gi")
+    }), {})
   })
-  description = "Reserved for future observability stack wiring."
+  description = "Observability stack settings for Grafana, Loki, Tempo, and Prometheus."
   default     = {}
 }
 

--- a/components/observability/main.tf
+++ b/components/observability/main.tf
@@ -1,0 +1,24 @@
+module "observability_namespace" {
+  source = "../../modules/k8s-namespace"
+
+  name = var.observability.namespace
+}
+
+module "observability" {
+  source = "../../modules/observability"
+
+  namespace = module.observability_namespace.name
+  grafana = merge(var.observability.grafana, {
+    service_type = var.observability.expose_public ? "NodePort" : "ClusterIP"
+    node_port    = var.observability.expose_public ? var.observability.grafana_node_port : null
+  })
+  loki  = var.observability.loki
+  tempo = var.observability.tempo
+  prometheus = merge(var.observability.prometheus, {
+    service_type = var.observability.expose_public ? "NodePort" : "ClusterIP"
+    node_port    = var.observability.expose_public ? var.observability.prometheus_node_port : null
+  })
+  recreate_revision = var.recreate_revision
+
+  depends_on = [module.observability_namespace]
+}

--- a/components/observability/outputs.tf
+++ b/components/observability/outputs.tf
@@ -1,0 +1,35 @@
+output "namespace" {
+  description = "Observability namespace."
+  value       = module.observability.namespace
+}
+
+output "grafana_release_name" {
+  description = "Grafana Helm release name."
+  value       = module.observability.grafana_release_name
+}
+
+output "grafana_url" {
+  description = "Configured Grafana URL when publicly exposed."
+  value       = var.observability.expose_public && var.api_server_host != null ? "http://${var.api_server_host}:${var.observability.grafana_host_port}" : null
+}
+
+output "prometheus_url" {
+  description = "Configured Prometheus URL when publicly exposed."
+  value = (
+    var.observability.expose_public && try(var.observability.prometheus.enabled, true) && var.api_server_host != null
+    ? "http://${var.api_server_host}:${var.observability.prometheus_host_port}"
+    : null
+  )
+}
+
+output "exposed_urls" {
+  description = "Consolidated observability endpoints."
+  value = {
+    grafana = var.observability.expose_public && var.api_server_host != null ? "http://${var.api_server_host}:${var.observability.grafana_host_port}" : null
+    prometheus = (
+      var.observability.expose_public && try(var.observability.prometheus.enabled, true) && var.api_server_host != null
+      ? "http://${var.api_server_host}:${var.observability.prometheus_host_port}"
+      : null
+    )
+  }
+}

--- a/components/observability/providers.tf
+++ b/components/observability/providers.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path = var.kubeconfig_path
+  insecure    = true
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = var.kubeconfig_path
+    insecure    = true
+  }
+}

--- a/components/observability/terraform.tfvars.example
+++ b/components/observability/terraform.tfvars.example
@@ -1,0 +1,56 @@
+kubeconfig_path = "./blitzinfra-kubeconfig"
+cluster_name    = "blitzinfra"
+api_server_host = "myserver"
+
+observability = {
+  namespace            = "observability"
+  expose_public        = false
+  grafana_node_port    = 32300
+  grafana_host_port    = 3000
+  prometheus_node_port = 32090
+  prometheus_host_port = 9090
+
+  grafana = {
+    release_name     = "grafana"
+    chart_repository = "https://grafana.github.io/helm-charts"
+    chart_name       = "grafana"
+    chart_version    = "10.5.15"
+    admin_user       = "admin"
+    admin_password   = "change-me"
+    persistence      = false
+    persistence_size = "5Gi"
+  }
+
+  loki = {
+    enabled          = false
+    release_name     = "loki"
+    chart_repository = "https://grafana.github.io/helm-charts"
+    chart_name       = "loki"
+    chart_version    = "6.30.1"
+    persistence      = false
+    persistence_size = "10Gi"
+  }
+
+  tempo = {
+    enabled                   = false
+    release_name              = "tempo"
+    chart_repository          = "https://grafana.github.io/helm-charts"
+    chart_name                = "tempo"
+    chart_version             = "1.23.3"
+    persistence               = false
+    persistence_size          = "10Gi"
+    metrics_generator_enabled = true
+  }
+
+  prometheus = {
+    enabled          = true
+    release_name     = "prometheus"
+    chart_repository = "https://prometheus-community.github.io/helm-charts"
+    chart_name       = "prometheus"
+    chart_version    = "27.20.0"
+    persistence      = false
+    persistence_size = "10Gi"
+  }
+}
+
+recreate_revision = ""

--- a/components/observability/variables.tf
+++ b/components/observability/variables.tf
@@ -1,0 +1,74 @@
+variable "kubeconfig_path" {
+  type        = string
+  description = "Path to the kubeconfig file of the target cluster."
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "kind cluster name used by the kubeconfig context."
+  default     = "blitzinfra"
+}
+
+variable "api_server_host" {
+  type        = string
+  description = "Host name or IP exposed by the kind cluster for public services."
+  default     = null
+  nullable    = true
+}
+
+variable "observability" {
+  type = object({
+    namespace            = optional(string, "observability")
+    expose_public        = optional(bool, false)
+    grafana_node_port    = optional(number, 32300)
+    grafana_host_port    = optional(number, 3000)
+    prometheus_node_port = optional(number, 32090)
+    prometheus_host_port = optional(number, 9090)
+    grafana = optional(object({
+      release_name     = optional(string, "grafana")
+      chart_repository = optional(string, "https://grafana.github.io/helm-charts")
+      chart_name       = optional(string, "grafana")
+      chart_version    = optional(string, "10.5.15")
+      admin_user       = optional(string, "admin")
+      admin_password   = optional(string, "admin")
+      persistence      = optional(bool, false)
+      persistence_size = optional(string, "5Gi")
+    }), {})
+    loki = optional(object({
+      enabled          = optional(bool, false)
+      release_name     = optional(string, "loki")
+      chart_repository = optional(string, "https://grafana.github.io/helm-charts")
+      chart_name       = optional(string, "loki")
+      chart_version    = optional(string, "6.30.1")
+      persistence      = optional(bool, false)
+      persistence_size = optional(string, "10Gi")
+    }), {})
+    tempo = optional(object({
+      enabled                   = optional(bool, false)
+      release_name              = optional(string, "tempo")
+      chart_repository          = optional(string, "https://grafana.github.io/helm-charts")
+      chart_name                = optional(string, "tempo")
+      chart_version             = optional(string, "1.23.3")
+      persistence               = optional(bool, false)
+      persistence_size          = optional(string, "10Gi")
+      metrics_generator_enabled = optional(bool, true)
+    }), {})
+    prometheus = optional(object({
+      enabled          = optional(bool, true)
+      release_name     = optional(string, "prometheus")
+      chart_repository = optional(string, "https://prometheus-community.github.io/helm-charts")
+      chart_name       = optional(string, "prometheus")
+      chart_version    = optional(string, "27.20.0")
+      persistence      = optional(bool, false)
+      persistence_size = optional(string, "10Gi")
+    }), {})
+  })
+  description = "Observability stack settings for Grafana, Loki, Tempo, and Prometheus."
+  default     = {}
+}
+
+variable "recreate_revision" {
+  type        = string
+  description = "Change this token to force replacement of observability releases."
+  default     = ""
+}

--- a/docs/exposed-urls.md
+++ b/docs/exposed-urls.md
@@ -12,6 +12,8 @@ Use Terraform outputs as the source of truth for the live values. This file is t
 | Backstage | `https://<api_server_host>:7007/` | `components/backstage` or `components/all` | Requires the matching Backstage host-port mapping on the kind cluster. |
 | Headlamp | `http://<api_server_host>:8443/` | `components/headlamp` or `components/all` | Requires the matching Headlamp host-port mapping on the kind cluster. |
 | Keycloak | `http://<api_server_host>:8080/` | `components/keycloak` | Requires `keycloak.expose_public = true` and the matching Keycloak host-port mapping on the kind cluster. |
+| Grafana | `http://<api_server_host>:3000` | `components/observability` or `components/all` | Requires `observability.expose_public = true` and the matching Grafana host-port mapping on the kind cluster. |
+| Prometheus | `http://<api_server_host>:9090` | `components/observability` or `components/all` | Requires `observability.expose_public = true`, `observability.prometheus.enabled = true`, and the matching Prometheus host-port mapping on the kind cluster. |
 
 For the current example configuration this means:
 
@@ -20,6 +22,8 @@ For the current example configuration this means:
 | Backstage | `https://myserver:7007/` |
 | Headlamp | `http://myserver:8443/` |
 | Keycloak | `http://myserver:8080/` |
+| Grafana | `http://myserver:3000` |
+| Prometheus | `http://myserver:9090` |
 
 ## Commands
 
@@ -27,6 +31,7 @@ For the current example configuration this means:
 terraform -chdir=components/all output exposed_urls
 terraform -chdir=components/backstage output exposed_urls
 terraform -chdir=components/keycloak output exposed_urls
+terraform -chdir=components/observability output exposed_urls
 ```
 
 ## Keycloak Without Port Forwarding

--- a/modules/kind-cluster/main.tf
+++ b/modules/kind-cluster/main.tf
@@ -75,6 +75,26 @@ resource "kind_cluster" "this" {
           protocol       = "TCP"
         }
       }
+
+      dynamic "extra_port_mappings" {
+        for_each = var.grafana_port_mapping != null ? [var.grafana_port_mapping] : []
+        content {
+          container_port = extra_port_mappings.value.node_port
+          host_port      = extra_port_mappings.value.host_port
+          listen_address = "0.0.0.0"
+          protocol       = "TCP"
+        }
+      }
+
+      dynamic "extra_port_mappings" {
+        for_each = var.prometheus_port_mapping != null ? [var.prometheus_port_mapping] : []
+        content {
+          container_port = extra_port_mappings.value.node_port
+          host_port      = extra_port_mappings.value.host_port
+          listen_address = "0.0.0.0"
+          protocol       = "TCP"
+        }
+      }
     }
 
     dynamic "node" {

--- a/modules/kind-cluster/variables.tf
+++ b/modules/kind-cluster/variables.tf
@@ -58,6 +58,24 @@ variable "keycloak_port_mapping" {
   default     = null
 }
 
+variable "grafana_port_mapping" {
+  type = object({
+    node_port = number
+    host_port = number
+  })
+  description = "Optional NodePort to host-port mapping for Grafana."
+  default     = null
+}
+
+variable "prometheus_port_mapping" {
+  type = object({
+    node_port = number
+    host_port = number
+  })
+  description = "Optional NodePort to host-port mapping for Prometheus."
+  default     = null
+}
+
 variable "kubeconfig_path" {
   type        = string
   description = "Absolute or relative path for the generated kubeconfig file."

--- a/modules/observability/main.tf
+++ b/modules/observability/main.tf
@@ -1,0 +1,221 @@
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+  }
+}
+
+locals {
+  prometheus_enabled = try(var.prometheus.enabled, true)
+  loki_enabled       = try(var.loki.enabled, false)
+  tempo_enabled      = try(var.tempo.enabled, false)
+
+  grafana_datasources = {
+    apiVersion = 1
+    datasources = concat(
+      local.loki_enabled ? [
+        {
+          name      = "Loki"
+          uid       = "loki"
+          type      = "loki"
+          access    = "proxy"
+          url       = "http://${var.loki.release_name}.${var.namespace}.svc.cluster.local:3100"
+          isDefault = false
+        }
+      ] : [],
+      local.prometheus_enabled ? [
+        {
+          name      = "Prometheus"
+          uid       = "prometheus"
+          type      = "prometheus"
+          access    = "proxy"
+          url       = "http://${var.prometheus.release_name}-server.${var.namespace}.svc.cluster.local"
+          isDefault = true
+        }
+      ] : [],
+      local.tempo_enabled ? [
+        {
+          name      = "Tempo"
+          uid       = "tempo"
+          type      = "tempo"
+          access    = "proxy"
+          url       = "http://${var.tempo.release_name}.${var.namespace}.svc.cluster.local:3100"
+          isDefault = !local.prometheus_enabled
+          jsonData = {
+            tracesToLogs = {
+              datasourceUid = "loki"
+            }
+          }
+        }
+      ] : []
+    )
+  }
+}
+
+resource "terraform_data" "recreate" {
+  input = var.recreate_revision
+}
+
+resource "helm_release" "loki" {
+  count            = local.loki_enabled ? 1 : 0
+  name             = var.loki.release_name
+  repository       = var.loki.chart_repository
+  chart            = var.loki.chart_name
+  version          = var.loki.chart_version
+  namespace        = var.namespace
+  create_namespace = false
+
+  values = [
+    yamlencode({
+      deploymentMode = "SingleBinary"
+      loki = {
+        commonConfig = {
+          replication_factor = 1
+        }
+      }
+      singleBinary = {
+        replicas = 1
+        persistence = {
+          enabled = var.loki.persistence
+          size    = var.loki.persistence_size
+        }
+      }
+      backend = {
+        replicas = 0
+      }
+      read = {
+        replicas = 0
+      }
+      write = {
+        replicas = 0
+      }
+      chunksCache = {
+        enabled = false
+      }
+      resultsCache = {
+        enabled = false
+      }
+      minio = {
+        enabled = false
+      }
+      test = {
+        enabled = false
+      }
+    })
+  ]
+
+  lifecycle {
+    replace_triggered_by = [terraform_data.recreate]
+  }
+}
+
+resource "helm_release" "tempo" {
+  count            = local.tempo_enabled ? 1 : 0
+  name             = var.tempo.release_name
+  repository       = var.tempo.chart_repository
+  chart            = var.tempo.chart_name
+  version          = var.tempo.chart_version
+  namespace        = var.namespace
+  create_namespace = false
+
+  values = [
+    yamlencode({
+      tempo = {
+        metricsGenerator = {
+          enabled = var.tempo.metrics_generator_enabled
+        }
+      }
+      persistence = {
+        enabled = var.tempo.persistence
+        size    = var.tempo.persistence_size
+      }
+      serviceMonitor = {
+        enabled = false
+      }
+      test = {
+        enabled = false
+      }
+    })
+  ]
+
+  lifecycle {
+    replace_triggered_by = [terraform_data.recreate]
+  }
+}
+
+resource "helm_release" "prometheus" {
+  count            = local.prometheus_enabled ? 1 : 0
+  name             = var.prometheus.release_name
+  repository       = var.prometheus.chart_repository
+  chart            = var.prometheus.chart_name
+  version          = var.prometheus.chart_version
+  namespace        = var.namespace
+  create_namespace = false
+
+  values = [
+    yamlencode({
+      alertmanager = {
+        enabled = false
+      }
+      pushgateway = {
+        enabled = false
+      }
+      server = {
+        service = {
+          type     = var.prometheus.service_type
+          nodePort = var.prometheus.service_type == "NodePort" ? var.prometheus.node_port : null
+        }
+        persistentVolume = {
+          enabled = var.prometheus.persistence
+          size    = var.prometheus.persistence_size
+        }
+      }
+    })
+  ]
+
+  lifecycle {
+    replace_triggered_by = [terraform_data.recreate]
+  }
+}
+
+resource "helm_release" "grafana" {
+  name             = var.grafana.release_name
+  repository       = var.grafana.chart_repository
+  chart            = var.grafana.chart_name
+  version          = var.grafana.chart_version
+  namespace        = var.namespace
+  create_namespace = false
+
+  values = [
+    yamlencode({
+      adminUser     = var.grafana.admin_user
+      adminPassword = var.grafana.admin_password
+      service = {
+        type     = var.grafana.service_type
+        nodePort = var.grafana.service_type == "NodePort" ? var.grafana.node_port : null
+      }
+      persistence = {
+        enabled = var.grafana.persistence
+        size    = var.grafana.persistence_size
+      }
+      datasources = {
+        "datasources.yaml" = local.grafana_datasources
+      }
+      testFramework = {
+        enabled = false
+      }
+    })
+  ]
+
+  depends_on = [
+    helm_release.loki,
+    helm_release.tempo,
+    helm_release.prometheus,
+  ]
+
+  lifecycle {
+    replace_triggered_by = [terraform_data.recreate]
+  }
+}

--- a/modules/observability/outputs.tf
+++ b/modules/observability/outputs.tf
@@ -1,0 +1,24 @@
+output "namespace" {
+  description = "Namespace where observability stack is installed."
+  value       = var.namespace
+}
+
+output "grafana_release_name" {
+  description = "Grafana Helm release name."
+  value       = helm_release.grafana.name
+}
+
+output "loki_release_name" {
+  description = "Loki Helm release name."
+  value       = try(helm_release.loki[0].name, null)
+}
+
+output "tempo_release_name" {
+  description = "Tempo Helm release name."
+  value       = try(helm_release.tempo[0].name, null)
+}
+
+output "prometheus_release_name" {
+  description = "Prometheus Helm release name when enabled."
+  value       = try(helm_release.prometheus[0].name, null)
+}

--- a/modules/observability/variables.tf
+++ b/modules/observability/variables.tf
@@ -1,0 +1,72 @@
+variable "namespace" {
+  type        = string
+  description = "Namespace where the observability stack is installed."
+}
+
+variable "grafana" {
+  type = object({
+    release_name     = optional(string, "grafana")
+    chart_repository = optional(string, "https://grafana.github.io/helm-charts")
+    chart_name       = optional(string, "grafana")
+    chart_version    = optional(string, "10.5.15")
+    service_type     = optional(string, "ClusterIP")
+    node_port        = optional(number)
+    admin_user       = optional(string, "admin")
+    admin_password   = optional(string, "admin")
+    persistence      = optional(bool, false)
+    persistence_size = optional(string, "5Gi")
+  })
+  description = "Grafana Helm release settings."
+  default     = {}
+}
+
+variable "loki" {
+  type = object({
+    enabled          = optional(bool, false)
+    release_name     = optional(string, "loki")
+    chart_repository = optional(string, "https://grafana.github.io/helm-charts")
+    chart_name       = optional(string, "loki")
+    chart_version    = optional(string, "6.30.1")
+    persistence      = optional(bool, false)
+    persistence_size = optional(string, "10Gi")
+  })
+  description = "Loki Helm release settings."
+  default     = {}
+}
+
+variable "tempo" {
+  type = object({
+    enabled                   = optional(bool, false)
+    release_name              = optional(string, "tempo")
+    chart_repository          = optional(string, "https://grafana.github.io/helm-charts")
+    chart_name                = optional(string, "tempo")
+    chart_version             = optional(string, "1.23.3")
+    persistence               = optional(bool, false)
+    persistence_size          = optional(string, "10Gi")
+    metrics_generator_enabled = optional(bool, true)
+  })
+  description = "Tempo Helm release settings."
+  default     = {}
+}
+
+variable "prometheus" {
+  type = object({
+    enabled          = optional(bool, true)
+    release_name     = optional(string, "prometheus")
+    chart_repository = optional(string, "https://prometheus-community.github.io/helm-charts")
+    chart_name       = optional(string, "prometheus")
+    chart_version    = optional(string, "27.20.0")
+    service_type     = optional(string, "ClusterIP")
+    node_port        = optional(number)
+    persistence      = optional(bool, false)
+    persistence_size = optional(string, "10Gi")
+  })
+  description = "Prometheus Helm release settings for metrics collection."
+  default     = {}
+}
+
+variable "recreate_revision" {
+  type        = string
+  description = "Change this token to force replacement of observability Helm releases."
+  default     = ""
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable observability stack that can be deployed into existing kind clusters alongside Backstage/Headlamp/Keycloak. 
- Make Grafana, Loki, Tempo, and optional Prometheus easy to install and wire together (datasources + basic defaults) using the repo's existing Terraform + Helm patterns.

### Description
- Add a new reusable module `modules/observability` that installs Helm releases for `loki`, `tempo`, `prometheus` (optional) and `grafana`, configures Grafana datasources for Loki/Tempo/Prometheus, and supports a `recreate_revision` replacement trigger. 
- Add a new deployable component root `components/observability` with kubeconfig-driven providers, a namespace bootstrap (`modules/k8s-namespace`) and wiring to call the observability module, plus `terraform.tfvars.example` and sensible defaults. 
- Make Grafana service type configurable via `observability.expose_public` (switches to `NodePort`) and surface a `grafana_url` output when exposed; the module also exposes release-name outputs for each chart. 
- Update `README.md` to document the new component in the layout, architecture diagrams, usage workflow, and example `terraform.tfvars.example` guidance.

### Testing
- Ran `git diff --check` with no issues reported. 
- Attempted `terraform fmt -recursive` but it could not run in this environment because the `terraform` CLI is not installed (format/validate was not executed here). 
- Basic repository smoke checks (file creation and content inspection) were performed locally in the rollout to ensure expected files and values exist.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfe28269ec8325837e9efbb659d25d)