### PR TITLE
[codex] Expose Alloy OTLP ingestion for Tempo

### DIFF
--- a/components/all/main.tf
+++ b/components/all/main.tf
@@ -323,6 +323,7 @@ module "observability" {
   })
   loki  = var.observability.loki
   tempo = var.observability.tempo
+  alloy = var.observability.alloy
   prometheus = merge(var.observability.prometheus, {
     service_type = var.observability.expose_public ? "NodePort" : "ClusterIP"
     node_port    = var.observability.expose_public ? var.observability.prometheus_node_port : null

--- a/components/all/terraform.tfvars.example
+++ b/components/all/terraform.tfvars.example
@@ -124,6 +124,9 @@ observability = {
   tempo = {
     enabled = false
   }
+  alloy = {
+    enabled = false
+  }
 }
 
 recreate_revision = ""

--- a/components/all/variables.tf
+++ b/components/all/variables.tf
@@ -295,6 +295,13 @@ variable "observability" {
       persistence      = optional(bool, false)
       persistence_size = optional(string, "10Gi")
     }), {})
+    alloy = optional(object({
+      enabled          = optional(bool, false)
+      release_name     = optional(string, "alloy")
+      chart_repository = optional(string, "https://grafana.github.io/helm-charts")
+      chart_name       = optional(string, "alloy")
+      chart_version    = optional(string, null)
+    }), {})
   })
   description = "Observability stack settings for Grafana, Loki, Tempo, and Prometheus."
   default     = {}

--- a/components/observability/terraform.tfvars.example
+++ b/components/observability/terraform.tfvars.example
@@ -42,6 +42,14 @@ observability = {
     metrics_generator_enabled = true
   }
 
+  alloy = {
+    enabled          = false
+    release_name     = "alloy"
+    chart_repository = "https://grafana.github.io/helm-charts"
+    chart_name       = "alloy"
+    chart_version    = null
+  }
+
   prometheus = {
     enabled          = true
     release_name     = "prometheus"

--- a/modules/observability/main.tf
+++ b/modules/observability/main.tf
@@ -45,8 +45,18 @@ locals {
           url       = "http://${var.tempo.release_name}.${var.namespace}.svc.cluster.local:3200"
           isDefault = !local.prometheus_enabled
           jsonData = {
-            tracesToLogs = {
-              datasourceUid = "loki"
+            tracesToLogsV2 = {
+              datasourceUid      = "loki"
+              spanStartTimeShift = "-1m"
+              spanEndTimeShift   = "1m"
+              filterByTraceID    = true
+              filterBySpanID     = false
+            }
+            serviceMap = {
+              datasourceUid = "prometheus"
+            }
+            nodeGraph = {
+              enabled = true
             }
           }
         }
@@ -260,7 +270,8 @@ resource "helm_release" "alloy" {
   values = [
     yamlencode({
       controller = {
-        type = "daemonset"
+        type     = "deployment"
+        replicas = 1
       }
       rbac = {
         create = true
@@ -269,6 +280,20 @@ resource "helm_release" "alloy" {
         create = true
       }
       alloy = {
+        extraPorts = [
+          {
+            name       = "otlp-grpc"
+            port       = 4317
+            targetPort = 4317
+            protocol   = "TCP"
+          },
+          {
+            name       = "otlp-http"
+            port       = 4318
+            targetPort = 4318
+            protocol   = "TCP"
+          },
+        ]
         configMap = {
           content = <<-ALLOY
             // Kubernetes pod log discovery
@@ -312,6 +337,15 @@ resource "helm_release" "alloy" {
             otelcol.receiver.otlp "default" {
               grpc { endpoint = "0.0.0.0:4317" }
               http { endpoint = "0.0.0.0:4318" }
+              output {
+                traces = [otelcol.processor.batch.default.input]
+              }
+            }
+
+            otelcol.processor.batch "default" {
+              timeout             = "1s"
+              send_batch_size     = 1024
+              send_batch_max_size = 2048
               output {
                 traces = [otelcol.exporter.otlp.tempo.input]
               }

--- a/references/observability-stack.md
+++ b/references/observability-stack.md
@@ -26,7 +26,7 @@ flowchart TD
         A3[Pod C]
     end
 
-    subgraph Alloy["Grafana Alloy (DaemonSet)"]
+    subgraph Alloy["Grafana Alloy (Deployment)"]
         LC[Log Collector\nloki.source.kubernetes]
         OR[OTLP Receiver\notelcol.receiver.otlp\n:4317 / :4318]
     end
@@ -62,7 +62,9 @@ flowchart TD
 
 ## Grafana Alloy
 
-Alloy is the **collector** — it runs as a DaemonSet (one pod per node) and is responsible for gathering telemetry and shipping it to the right backend.
+Alloy is the **collector**. This stack runs one Deployment replica so every span
+from a distributed trace reaches the same processing pipeline. Alloy receives
+OTLP on ports 4317/4318, batches spans, and forwards them to Tempo.
 
 In this stack Alloy does two things:
 


### PR DESCRIPTION
## What changed

- run Alloy as a singleton deployment for the shared trace pipeline
- expose OTLP gRPC and HTTP service ports
- batch spans before forwarding them to Tempo
- wire Alloy configuration through the combined infrastructure component
- enable Grafana trace-to-logs, service-map, and node-graph integrations
- update observability examples and documentation

## Why

The Alloy receiver listened on OTLP ports inside its pods, but its Kubernetes service did not expose those ports, so applications could not send traces to it.

## Validation

- `terraform fmt -check -recursive`
- `terraform validate` in `components/observability`
- live Alloy Helm release is deployed and ready
- synthetic OTLP trace accepted by Alloy and retrieved from Tempo by trace ID
